### PR TITLE
fix (packages/nhost-js): extract query name from TypedDocumentNode

### DIFF
--- a/packages/nhost-js/CHANGELOG.md
+++ b/packages/nhost-js/CHANGELOG.md
@@ -1,3 +1,7 @@
+# dev
+
+- fix: packages/nhost-js: extract query name from TypedDocumentNode #36
+
 # 5.0.0-beta.6
 
 - fix (packages/nhost-js): added missing endpoints (storage) and baseURL (functions) #35

--- a/packages/nhost-js/CHANGELOG.md
+++ b/packages/nhost-js/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dev
 
-- fix: packages/nhost-js: extract query name from TypedDocumentNode #36
+- fix (packages/nhost-js): extract query name from TypedDocumentNode #36
 
 # 5.0.0-beta.6
 

--- a/packages/nhost-js/src/graphql/client.ts
+++ b/packages/nhost-js/src/graphql/client.ts
@@ -167,10 +167,15 @@ export const createAPIClient = (
     options?: RequestInit,
   ): Promise<FetchResponse<GraphQLResponse<TResponseData>>> {
     if (typeof requestOrDocument === "object" && "kind" in requestOrDocument) {
-      // Handle TypedDocumentNode
+      const definition = requestOrDocument.definitions[0];
+
       const request: GraphQLRequest<TVariables> = {
         query: requestOrDocument.loc?.source.body || "",
         variables: variablesOrOptions as TVariables,
+        operationName:
+          definition && "name" in definition
+            ? definition.name?.value
+            : undefined,
       };
       return executeOperation(request, options);
     } else {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Extract operation name from TypedDocumentNode definitions

- Add proper handling for GraphQL operation names

- Improve TypedDocumentNode processing in GraphQL client


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.ts</strong><dd><code>Extract operation name from TypedDocumentNode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/nhost-js/src/graphql/client.ts

<li>Extract operation name from TypedDocumentNode's first definition<br> <li> Add conditional check for definition name existence<br> <li> Include operationName in GraphQL request object


</details>


  </td>
  <td><a href="https://github.com/nhost/sdk-experiment/pull/36/files#diff-cbd71dd3404704ff9d9c84273572fcac6f041532eef597de8a714249c08559c4">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>