### PR TITLE
fix (packages/nhost-js): force refresh correctly if marginSeconds is set to 0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,4 @@
-# @nhost/docs
-
-## main
-
+- 20250825 fix (packages/nhost-js): force refresh correctly if marginSeconds is set to 0 #54
 - 20250811 feat (package/nhost-js): update openapi specs and properly generate formData when uploading/updating files #47
 - 20250705 feat chore (nhost-js): update openapi #44
 - 20250704 feat (packages/nhost-js): added functions.post method and improve documentation #43

--- a/docs/reference/javascript/nhost-js/session.mdx
+++ b/docs/reference/javascript/nhost-js/session.mdx
@@ -586,11 +586,11 @@ refresh the token using the provided auth client.
 
 #### Parameters
 
-| Parameter       | Type                                | Default value | Description                                                                      |
-| --------------- | ----------------------------------- | ------------- | -------------------------------------------------------------------------------- |
-| `auth`          | [`Client`](auth#client)         | `undefined`   | The authentication client to use for token refresh                               |
-| `storage`       | [`SessionStorage`](#sessionstorage) | `undefined`   | The session storage implementation                                               |
-| `marginSeconds` | `number`                            | `60`          | How many seconds before expiration to trigger a refresh (defaults to 60 seconds) |
+| Parameter       | Type                                | Default value | Description                                                                                                                                                                       |
+| --------------- | ----------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `auth`          | [`Client`](auth#client)         | `undefined`   | The authentication client to use for token refresh                                                                                                                                |
+| `storage`       | [`SessionStorage`](#sessionstorage) | `undefined`   | The session storage implementation                                                                                                                                                |
+| `marginSeconds` | `number`                            | `60`          | The number of seconds before the token expiration to refresh the session. If the token is still valid for this duration, it will not be refreshed. Set to 0 to force the refresh. |
 
 #### Returns
 

--- a/packages/nhost-js/CHANGELOG.md
+++ b/packages/nhost-js/CHANGELOG.md
@@ -1,4 +1,4 @@
-- fix (packages/nhost-js): force refresh correctly if marginSeconds is set to 0
+- fix (packages/nhost-js): force refresh correctly if marginSeconds is set to 0 #54
 
 # 5.0.0-beta.9
 

--- a/packages/nhost-js/CHANGELOG.md
+++ b/packages/nhost-js/CHANGELOG.md
@@ -1,3 +1,5 @@
+- fix (packages/nhost-js): force refresh correctly if marginSeconds is set to 0
+
 # 5.0.0-beta.9
 
 - fix (packages/nhost-js): if session doesn't have decodedToken treat as expired #49

--- a/packages/nhost-js/src/session/refreshSession.ts
+++ b/packages/nhost-js/src/session/refreshSession.ts
@@ -36,7 +36,7 @@ const lock: Lock =
  *
  * @param auth - The authentication client to use for token refresh
  * @param storage - The session storage implementation
- * @param marginSeconds - How many seconds before expiration to trigger a refresh (defaults to 60 seconds)
+ * @param marginSeconds - The number of seconds before the token expiration to refresh the session. If the token is still valid for this duration, it will not be refreshed. Set to 0 to force the refresh.
  * @returns A promise that resolves to the current session (refreshed if needed) or null if no session exists
  */
 export const refreshSession = async (
@@ -152,6 +152,11 @@ const _needsRefresh = (storage: SessionStorage, marginSeconds = 60) => {
     // if the session does not have a valid decoded token, treat it as expired
     // as we can't determine its validity
     return { session, needsRefresh: true, sessionExpired: true };
+  }
+
+  // Force refresh if marginSeconds is 0
+  if (marginSeconds === 0) {
+    return { session, needsRefresh: true, sessionExpired: false };
   }
 
   const currentTime = Date.now();


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed force refresh logic when `marginSeconds` is 0

- Updated documentation for `marginSeconds` parameter

- Added explicit check to force refresh when margin is zero


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check marginSeconds"] --> B{"marginSeconds === 0?"}
  B -->|Yes| C["Force refresh"]
  B -->|No| D["Check token expiration"]
  D --> E["Refresh if needed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>refreshSession.ts</strong><dd><code>Fix force refresh logic for zero margin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/nhost-js/src/session/refreshSession.ts

<ul><li>Added explicit check for <code>marginSeconds === 0</code> to force refresh<br> <li> Updated JSDoc comment to clarify force refresh behavior<br> <li> Fixed logic to properly handle zero margin seconds case</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/sdk-experiment/pull/54/files#diff-578cd1f069f1742b4a1aeabaaed852562659c6a830a4b51df0c26d52af478051">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document force refresh fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/nhost-js/CHANGELOG.md

- Added changelog entry for the force refresh fix


</details>


  </td>
  <td><a href="https://github.com/nhost/sdk-experiment/pull/54/files#diff-b6200685d3e776a9e74d320e54959fe992d1a3c534df1634013979b6685438ba">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

